### PR TITLE
Revert "Bump python from 3.11-slim to 3.13-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.11-slim
 
 # Default UID and GID (can be overridden)
 ARG USER_UID=1000


### PR DESCRIPTION
Reverts GitTimeraider/Directadmin-Emailforwarder#1