### PR TITLE
Potential fix for code scanning alert no. 14: URL redirection from remote source

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -6,7 +6,7 @@ import qrcode
 import io
 import base64
 from datetime import datetime
-
+from urllib.parse import urlparse
 auth_bp = Blueprint('auth', __name__)
 
 @auth_bp.route('/login', methods=['GET', 'POST'])
@@ -32,7 +32,11 @@ def login():
                     login_user(user)
 
                     next_page = request.args.get('next')
-                    return redirect(next_page) if next_page else redirect(url_for('index'))
+                    if next_page:
+                        safe_next = next_page.replace('\\', '')
+                        if not urlparse(safe_next).netloc and not urlparse(safe_next).scheme:
+                            return redirect(safe_next)
+                    return redirect(url_for('index'))
                 else:
                     flash('Invalid 2FA code', 'error')
                     # Show 2FA form again with username preserved
@@ -54,7 +58,11 @@ def login():
                     login_user(user)
 
                     next_page = request.args.get('next')
-                    return redirect(next_page) if next_page else redirect(url_for('index'))
+                    if next_page:
+                        safe_next = next_page.replace('\\', '')
+                        if not urlparse(safe_next).netloc and not urlparse(safe_next).scheme:
+                            return redirect(safe_next)
+                    return redirect(url_for('index'))
             else:
                 flash('Invalid username or password', 'error')
 


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/14](https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/14)

To fix the open redirect vulnerability, we should validate the `next_page` parameter before using it in a redirect. The best way is to ensure that the redirect target is a relative path (i.e., does not contain a scheme or netloc), which prevents redirection to external sites. This can be done using Python's `urllib.parse.urlparse` to check that both the `scheme` and `netloc` attributes are empty. Additionally, we should remove any backslashes from the input, as browsers may treat them as path separators. If the validation fails, we should redirect to a safe default (e.g., the home page or index). The changes should be applied to both places where `next_page` is used: lines 35 and 57 in `app/auth.py`. We need to import `urlparse` from `urllib.parse`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
