### PR TITLE
Potential fix for code scanning alert no. 12: Information exposure through an exception

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -119,7 +119,8 @@ def test_connection():
 
     except Exception as e:
         print(f"Test connection error: {str(e)}")
-        return jsonify({'error': str(e), 'success': False}), 200
+        print(traceback.format_exc())
+        return jsonify({'error': 'An internal error has occurred.', 'success': False}), 200
 
 # Debug route to check available routes
 @settings_bp.route('/api/debug-routes', methods=['GET'])


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/12](https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/12)

To fix the problem, we should avoid returning the raw exception message to the client. Instead, we should log the exception (including the stack trace) on the server for debugging, and return a generic error message to the client. This ensures that sensitive information is not leaked, while still allowing developers to diagnose issues using server logs.

**Steps:**
- In the `except` block of the `test_connection` route, replace `str(e)` in the JSON response with a generic error message (e.g., "An internal error has occurred.").
- Log the exception and stack trace to the server console using `print()` or a logging framework.
- No changes to imports are needed, as `traceback` is already imported.

**Files/regions to change:**  
- Only `app/settings.py`, lines 120-122 (the `except` block in `test_connection`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
