### PR TITLE
Potential fix for code scanning alert no. 11: Information exposure through an exception

### DIFF
--- a/app/directadmin_api.py
+++ b/app/directadmin_api.py
@@ -167,7 +167,10 @@ class DirectAdminAPI:
             return False, "Failed to connect. Please check your credentials."
 
         except Exception as e:
-            return False, f"Connection error: {str(e)}"
+            import traceback
+            print(f"Connection error: {str(e)}")
+            traceback.print_exc()
+            return False, "Connection error: Unable to connect to DirectAdmin."
 
     def get_email_accounts(self):
         """Get all email accounts for the domain"""


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/11](https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/11)

To fix the problem, we need to ensure that the `test_connection()` method in `DirectAdminAPI` (app/directadmin_api.py) does not return exception details to the caller. Instead, it should return a generic error message when an exception occurs, and log the detailed error server-side. Specifically, in the `except Exception as e:` block (line 169), replace `return False, f"Connection error: {str(e)}"` with `return False, "Connection error: Unable to connect to DirectAdmin."` and log the exception using `traceback.print_exc()` or similar. This change ensures that the user-facing API in app/settings.py only receives a generic error message, preventing information exposure.

**Files/regions to change:**  
- app/directadmin_api.py: In the `test_connection()` method, update the exception handler to return a generic error message and log the detailed error.
- No changes are needed in app/settings.py, as the message returned from `test_connection()` will now be safe.

**Methods/imports/definitions needed:**  
- Ensure that `traceback` is imported in app/directadmin_api.py (already present).
- No new dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
