### PR TITLE
Potential fix for code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -86,7 +86,7 @@ def update_da_config():
         print(f"Error in POST da-config: {str(e)}")
         print(traceback.format_exc())
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'An internal error has occurred. Please try again later.'}), 500
 
 # Keep test-connection separate
 @settings_bp.route('/api/test-connection', methods=['POST'])


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/10](https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/10)

To fix the problem, we should avoid exposing the raw exception message to the client. Instead, we should return a generic error message such as "An internal error has occurred" or "Failed to save settings", while logging the actual exception and stack trace on the server for debugging purposes. This change should be made only in the error handler of the `update_da_config` function (lines 85-89 in `app/settings.py`). No changes are needed to the rest of the code. No new imports are required, as logging/printing and `traceback` are already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
