### PR TITLE
Potential fix for code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -25,7 +25,8 @@ def get_da_config():
         })
     except Exception as e:
         print(f"Error in GET da-config: {e}")
-        return jsonify({'error': str(e)}), 500
+        print(traceback.format_exc())
+        return jsonify({'error': 'An internal error has occurred. Please try again later.'}), 500
 
 @settings_bp.route('/api/da-config', methods=['POST'])
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/9](https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/9)

To fix the problem, we should avoid returning the stringified exception (`str(e)`) to the client. Instead, return a generic error message such as "An internal error has occurred. Please try again later." to the client, and log the detailed error (including stack trace) on the server for debugging purposes. This change should be made in the exception handler of the `get_da_config` function (lines 26-28 in `app/settings.py`). No new imports are needed, as `traceback` is already imported and `print` is used for logging. The fix is to replace the vulnerable line with a generic error message, and optionally log the stack trace for server-side diagnostics.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
