### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -234,8 +234,7 @@ def create_app():
             print(f"Error deleting forwarder: {str(e)}")
             traceback.print_exc()
             return jsonify({
-                'error': 'Failed to delete forwarder',
-                'details': str(e)
+                'error': 'Failed to delete forwarder'
             }), 500
 
     # ===== Error Handlers =====


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/8](https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/8)

To fix the problem, we should avoid returning the exception message (`str(e)`) in the API response. Instead, we should return only a generic error message to the client, while logging the full exception details (including stack trace) on the server for debugging purposes. This can be done by removing the `'details': str(e)` line from the JSON response in the exception handler for the `delete_forwarder` endpoint. No changes to the logging are needed, as the stack trace is already printed to the server logs.

**What to change:**  
- In `app/main.py`, in the `delete_forwarder` function, remove the `'details': str(e)` field from the JSON response in the exception handler (lines 236–239).
- No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
