### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/app/directadmin_api.py
+++ b/app/directadmin_api.py
@@ -495,7 +495,7 @@ class DirectAdminAPI:
 
         except Exception as e:
             print(f"Error deleting forwarder: {e}")
-            return False, str(e)
+            return False, "An error occurred while deleting the forwarder"
 
     def validate_email(self, email):
         """Basic email validation"""


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/7](https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/7)

To fix the problem, we should avoid returning the raw exception message from `DirectAdminAPI.delete_forwarder` to the client. Instead, we should return a generic error message for the client, while logging the actual exception details on the server for debugging purposes. This involves modifying the `delete_forwarder` method in `app/directadmin_api.py` so that, in the event of an exception, it returns a generic error message (e.g., "An error occurred while deleting the forwarder") instead of `str(e)`. The actual exception should be logged using `print` or a logging framework. No changes are needed in `app/main.py` since it already returns a generic error message in the outer exception handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
