### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -187,8 +187,7 @@ def create_app():
             print(f"Error creating forwarder: {str(e)}")
             traceback.print_exc()
             return jsonify({
-                'error': 'Failed to create forwarder',
-                'details': str(e)
+                'error': 'Failed to create forwarder'
             }), 500
 
     @app.route('/api/forwarders', methods=['DELETE'])


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/5](https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/5)

To fix the problem, we should avoid sending the exception details (`str(e)`) to the client. Instead, we should log the exception (including the stack trace) on the server for debugging purposes, and return a generic error message to the client. This change should be made in the `create_forwarder` function (lines 186-192). The same pattern should be checked elsewhere, but only the shown code should be changed. No new imports are needed, as `traceback` and `print` are already used for logging. The error response should simply be:

```python
return jsonify({'error': 'Failed to create forwarder'}), 500
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
