### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/app/directadmin_api.py
+++ b/app/directadmin_api.py
@@ -442,7 +442,7 @@ class DirectAdminAPI:
             print(f"Error creating forwarder: {e}")
             import traceback
             traceback.print_exc()
-            return False, str(e)
+            return False, "An error occurred while creating the forwarder"
 
     def delete_forwarder(self, address):
         """Delete an email forwarder"""


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/4](https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/4)

To fix the problem, we should ensure that exception details are not sent to the user in API responses. Instead, return a generic error message and log the actual exception details on the server for debugging. Specifically, in `DirectAdminAPI.create_forwarder`, change the return value in the exception handler from `False, str(e)` to `False, "An error occurred while creating the forwarder"`. The detailed exception should still be logged server-side. No changes are needed in `app/main.py` since it already returns a generic error message in the outer exception handler, but the error returned from `create_forwarder` should also be generic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
