### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/app/directadmin_api.py
+++ b/app/directadmin_api.py
@@ -442,7 +442,7 @@ class DirectAdminAPI:
             print(f"Error creating forwarder: {e}")
             import traceback
             traceback.print_exc()
-            return False, str(e)
+            return False, "An error occurred while creating the forwarder"
 
     def delete_forwarder(self, address):
         """Delete an email forwarder"""

--- a/app/main.py
+++ b/app/main.py
@@ -180,7 +180,7 @@ def create_app():
                 })
             else:
                 return jsonify({
-                    'error': message
+                    'error': 'Failed to create forwarder'
                 }), 400
 
         except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/3](https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/3)

To fix the problem, we need to ensure that exception messages are not exposed to the user. Instead, we should return a generic error message in the API response and log the actual exception details on the server for debugging. Specifically:

- In `DirectAdminAPI.create_forwarder`, when an exception occurs, return a generic error message instead of `str(e)`.
- In the Flask route in `app/main.py`, do not expose the exception message to the user; only return a generic error.
- Ensure that exception details are logged on the server (e.g., using `print` or `traceback.print_exc()`), but not sent to the client.

The required changes are:
- In `app/directadmin_api.py`, change the return value in the `except` block of `create_forwarder` to a generic message.
- In `app/main.py`, no change is needed in the `except` block, as it already returns a generic error message. However, the `else` block in the route should also return a generic error message instead of the potentially sensitive `message` from the API.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
