### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -135,7 +135,6 @@ def create_app():
             traceback.print_exc()
             return jsonify({
                 'error': 'Failed to fetch forwarders',
-                'details': str(e),
                 'forwarders': []
             }), 500
 


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/2](https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/2)

To fix the problem, we should avoid returning the exception message (`str(e)`) in the API response. Instead, we should return a generic error message to the client, while logging the detailed error (including the stack trace) on the server for debugging purposes. This ensures that sensitive information is not leaked to the client, but developers can still diagnose issues using the server logs.

Specifically, in `app/main.py`, in the exception handler for the `/api/forwarders` GET endpoint (lines 133–140), remove the `'details': str(e)` field from the JSON response. The server-side logging (`print` and `traceback.print_exc()`) can remain as-is.

No new imports or methods are required, as logging is already being done.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
