### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -93,7 +93,6 @@ def create_app():
             traceback.print_exc()
             return jsonify({
                 'error': 'Failed to fetch email accounts',
-                'details': str(e),
                 'accounts': []
             }), 500
 


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/1](https://github.com/GitTimeraider/Directadmin-Emailforwarder/security/code-scanning/1)

To fix the problem, we should avoid exposing the exception message (`str(e)`) to the client in the API response. Instead, return a generic error message, and log the detailed exception (including stack trace) on the server for debugging. Specifically, in the `/api/email-accounts` route, remove the `'details': str(e)` field from the JSON response in the exception handler (lines 94-97). The same pattern should be applied to similar routes if present, but per instructions, only change the code shown.

No new imports are needed, as `traceback` and `print` are already used for server-side logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
