### PR TITLE
Hide the app nav on the login page

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,6 +8,7 @@
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='assets/img/ico_main_25.ico') }}">
 </head>
 <body data-theme="{{ current_user.theme_preference if current_user.is_authenticated else 'dark' }}">
+{% if current_user.is_authenticated %}
 <nav>
     <div class="nav-brand">
         <a href="{{ url_for('dashboard') }}">DirectAdmin 📧 Forwarder</a>
@@ -30,6 +31,7 @@
         <a href="{{ url_for('auth.logout') }}">Logout</a>
     </div>
 </nav>
+{% endif %}
 
     <main class="site-main">
     {% with messages = get_flashed_messages(with_categories=true) %}

--- a/static/base.js
+++ b/static/base.js
@@ -4,60 +4,61 @@ document.addEventListener('DOMContentLoaded', function() {
     const navLinks = document.getElementById('navLinks');
     const body = document.body;
 
-    // Create overlay element
-    const overlay = document.createElement('div');
-    overlay.className = 'nav-overlay';
-    document.body.appendChild(overlay);
+    // Nav is only rendered for authenticated users (e.g. not on the login page)
+    if (hamburger && navLinks) {
+        // Create overlay element
+        const overlay = document.createElement('div');
+        overlay.className = 'nav-overlay';
+        document.body.appendChild(overlay);
 
-    // Toggle menu function
-    function toggleMenu() {
-        hamburger.classList.toggle('active');
-        navLinks.classList.toggle('active');
-        overlay.classList.toggle('active');
-        body.classList.toggle('menu-open');
-    }
-
-    // Hamburger click
-    if (hamburger) {
-        hamburger.addEventListener('click', toggleMenu);
-    }
-
-    // Overlay click (close menu)
-    overlay.addEventListener('click', function() {
-        if (navLinks.classList.contains('active')) {
-            toggleMenu();
+        // Toggle menu function
+        function toggleMenu() {
+            hamburger.classList.toggle('active');
+            navLinks.classList.toggle('active');
+            overlay.classList.toggle('active');
+            body.classList.toggle('menu-open');
         }
-    });
 
-    // Close menu when clicking a link
-    const navLinksItems = navLinks.querySelectorAll('a');
-    navLinksItems.forEach(link => {
-        link.addEventListener('click', function() {
-            if (window.innerWidth <= 768) {
+        // Hamburger click
+        hamburger.addEventListener('click', toggleMenu);
+
+        // Overlay click (close menu)
+        overlay.addEventListener('click', function() {
+            if (navLinks.classList.contains('active')) {
                 toggleMenu();
             }
         });
-    });
 
-    // Handle window resize
-    let resizeTimer;
-    window.addEventListener('resize', function() {
-        clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(function() {
-            if (window.innerWidth > 768) {
-                // Reset menu state on desktop
-                hamburger.classList.remove('active');
-                navLinks.classList.remove('active');
-                overlay.classList.remove('active');
-                body.classList.remove('menu-open');
-            }
-        }, 250);
-    });
+        // Close menu when clicking a link
+        const navLinksItems = navLinks.querySelectorAll('a');
+        navLinksItems.forEach(link => {
+            link.addEventListener('click', function() {
+                if (window.innerWidth <= 768) {
+                    toggleMenu();
+                }
+            });
+        });
+
+        // Handle window resize
+        let resizeTimer;
+        window.addEventListener('resize', function() {
+            clearTimeout(resizeTimer);
+            resizeTimer = setTimeout(function() {
+                if (window.innerWidth > 768) {
+                    // Reset menu state on desktop
+                    hamburger.classList.remove('active');
+                    navLinks.classList.remove('active');
+                    overlay.classList.remove('active');
+                    body.classList.remove('menu-open');
+                }
+            }, 250);
+        });
+    }
 
     // Theme persistence - apply theme from localStorage if different from server preference
     const savedTheme = localStorage.getItem('theme-preference');
     const currentTheme = body.getAttribute('data-theme');
-    
+
     if (savedTheme && savedTheme !== currentTheme) {
         body.setAttribute('data-theme', savedTheme);
     }


### PR DESCRIPTION
## Summary
- The nav bar (Dashboard/Settings/Profile/Admin/Logout) was rendering on the login screen even though the user isn't authenticated yet and none of those links are meaningful there.
- `<nav>` in `base.html` is now only rendered when `current_user.is_authenticated`.
- Guarded the hamburger-menu JS in `base.js` so it no-ops cleanly on pages without a nav instead of throwing on a `null` lookup.

This is a follow-up to the styling refresh merged in #153.

## Test plan
- [x] Ran the app locally and confirmed the login page shows only the login card, no header/nav.
- [x] Confirmed no JS console errors on the login page (hamburger/nav elements absent).
- [x] Logged in and confirmed the full nav (Dashboard/Settings/Profile/Admin/Logout) renders normally, in both desktop and mobile (hamburger) layouts.


---
_Generated by [Claude Code](https://claude.ai/code/session_017PP1s92Jxe9s7cYmwtQ4Ue)_